### PR TITLE
feat: allow passing of subdomain on register

### DIFF
--- a/acmetxt.go
+++ b/acmetxt.go
@@ -14,6 +14,7 @@ type ACMETxt struct {
 	Password string
 	ACMETxtPost
 	AllowFrom cidrslice
+	Subdomain string `json:"subdomain,omitempty"`
 }
 
 // ACMETxtPost holds the DNS part of the ACMETxt struct
@@ -84,10 +85,17 @@ func (a ACMETxt) allowedFromList(ips []string) bool {
 }
 
 func newACMETxt() ACMETxt {
+	return newACMETxtWithSubdomain("")
+}
+func newACMETxtWithSubdomain(subdomain string) ACMETxt {
 	var a = ACMETxt{}
 	password := generatePassword(40)
 	a.Username = uuid.New()
 	a.Password = password
-	a.Subdomain = uuid.New().String()
+	if subdomain == "" {
+		a.Subdomain = uuid.New().String()
+	} else {
+		a.Subdomain = subdomain
+	}
 	return a
 }

--- a/api.go
+++ b/api.go
@@ -49,7 +49,17 @@ func webRegisterPost(w http.ResponseWriter, r *http.Request, _ httprouter.Params
 	}
 
 	// Create new user
-	nu, err := DB.Register(aTXT.AllowFrom)
+	var nu ACMETxt
+	if aTXT.Subdomain == "" {
+		nu, err = DB.Register(aTXT.AllowFrom)
+	} else {
+		if !validSubdomain(aTXT.Subdomain) {
+			err = fmt.Errorf("invalid subdomain: %s", aTXT.Subdomain)
+		} else {
+			nu, err = DB.RegisterWithSubdomain(aTXT.AllowFrom, aTXT.Subdomain)
+		}
+	}
+
 	if err != nil {
 		errstr := fmt.Sprintf("%v", err)
 		reg = jsonError(errstr)

--- a/db.go
+++ b/db.go
@@ -170,10 +170,27 @@ func (d *acmedb) NewTXTValuesInTransaction(tx *sql.Tx, subdomain string) error {
 	return err
 }
 
+// Register creates a new ACMETxt entry in the database with a random subdomain.
 func (d *acmedb) Register(afrom cidrslice) (ACMETxt, error) {
+	return d.RegisterWithSubdomain(afrom, uuid.New().String())
+}
+
+// RegisterWithSubdomain creates a new ACMETxt entry in the database with a given subdomain.
+func (d *acmedb) RegisterWithSubdomain(afrom cidrslice, subdomain string) (ACMETxt, error) {
+
+	// ensure the subdomain is not already in use
+	exists, err := d.subdomainExists(subdomain)
+	if err != nil {
+		log.WithFields(log.Fields{"error": err.Error()}).Error("Error in subdomainExists check")
+		return ACMETxt{}, errors.New("database error")
+	}
+	if exists {
+		log.WithFields(log.Fields{"subdomain": subdomain}).Debug("Subdomain already exists")
+		return ACMETxt{}, errors.New("subdomain already exists")
+	}
+
 	d.Mutex.Lock()
 	defer d.Mutex.Unlock()
-	var err error
 	tx, err := d.DB.Begin()
 	// Rollback if errored, commit if not
 	defer func() {
@@ -183,7 +200,7 @@ func (d *acmedb) Register(afrom cidrslice) (ACMETxt, error) {
 		}
 		_ = tx.Commit()
 	}()
-	a := newACMETxt()
+	a := newACMETxtWithSubdomain(subdomain)
 	a.AllowFrom = cidrslice(afrom.ValidEntries())
 	passwordHash, err := bcrypt.GenerateFromPassword([]byte(a.Password), 10)
 	regSQL := `
@@ -340,4 +357,39 @@ func (d *acmedb) GetBackend() *sql.DB {
 
 func (d *acmedb) SetBackend(backend *sql.DB) {
 	d.DB = backend
+}
+
+func (d *acmedb) subdomainExists(subdomain string) (bool, error) {
+	d.Mutex.Lock()
+	defer d.Mutex.Unlock()
+	var results []ACMETxt
+	getSQL := `
+	SELECT Subdomain
+	FROM records
+	WHERE Subdomain=$1 LIMIT 1
+	`
+	if Config.Database.Engine == "sqlite3" {
+		getSQL = getSQLiteStmt(getSQL)
+	}
+
+	sm, err := d.DB.Prepare(getSQL)
+	if err != nil {
+		return false, err
+	}
+	defer sm.Close()
+	rows, err := sm.Query(subdomain)
+	if err != nil {
+		return false, err
+	}
+	defer rows.Close()
+
+	// It will only be one row though
+	for rows.Next() {
+		txt, err := getModelFromRow(rows)
+		if err != nil {
+			return false, err
+		}
+		results = append(results, txt)
+	}
+	return len(results) > 0, nil
 }

--- a/db_test.go
+++ b/db_test.go
@@ -4,8 +4,9 @@ import (
 	"database/sql"
 	"database/sql/driver"
 	"errors"
-	"github.com/erikstmartin/go-testdb"
 	"testing"
+
+	"github.com/erikstmartin/go-testdb"
 )
 
 type testResult struct {
@@ -46,6 +47,38 @@ func TestRegisterNoCIDR(t *testing.T) {
 	_, err := DB.Register(cidrslice{})
 	if err != nil {
 		t.Errorf("Registration failed, got error [%v]", err)
+	}
+}
+
+func TestRegisterWithSubdomain(t *testing.T) {
+	// Register with subdomain tests
+	_, err := DB.RegisterWithSubdomain(cidrslice{}, "29d5db12-4ef8-431d-963e-9218caafb14b")
+	if err != nil {
+		t.Errorf("Registration with subdomain failed, got error [%v]", err)
+	}
+
+}
+
+func TestRegisterWithInvalidSubdomain(t *testing.T) {
+
+	// Invalid subdomain
+	_, err := DB.RegisterWithSubdomain(cidrslice{}, "invalid-subdomain!")
+	if err == nil {
+		t.Errorf("Expected error for invalid subdomain, but got none")
+	}
+}
+
+func TestRegisterWithAlreadyExistingSubdomain(t *testing.T) {
+	// Register with subdomain tests
+	_, err := DB.RegisterWithSubdomain(cidrslice{}, "29d5db12-4ef8-431d-963e-9218caafb14b")
+	if err != nil {
+		t.Errorf("Registration with subdomain failed, got error [%v]", err)
+	}
+
+	// Try to register again with the same subdomain
+	_, err = DB.RegisterWithSubdomain(cidrslice{}, "29d5db12-4ef8-431d-963e-9218caafb14b")
+	if err == nil {
+		t.Errorf("Expected error for already existing subdomain, but got none")
 	}
 }
 

--- a/types.go
+++ b/types.go
@@ -70,6 +70,7 @@ type acmedb struct {
 type database interface {
 	Init(string, string) error
 	Register(cidrslice) (ACMETxt, error)
+	RegisterWithSubdomain(cidrslice, string) (ACMETxt, error)
 	GetByUsername(uuid.UUID) (ACMETxt, error)
 	GetTXTForDomain(string) ([]string, error)
 	Update(ACMETxtPost) error


### PR DESCRIPTION
Optionally allow passing the subdomain on register.

This allows users to predefine their CNAME Records in their DNS Server if automation is not possible.